### PR TITLE
API wrapper

### DIFF
--- a/iip_search_app/urls_app.py
+++ b/iip_search_app/urls_app.py
@@ -15,6 +15,8 @@ urlpatterns = patterns('',
     url( r'^search/$',  'iip_search_app.views.iip_results_z', name=u'search_url' ),
     url( r'^search_zotero/$',  'iip_search_app.views.iip_results_z', name=u'z_search_url'),
 
+    url( r'^api/$', 'iip_search_app.views.api_wrapper', name=u"api_wrapper"),
+
     # url( r'^viewinscr/(?P<inscrid>.*)/$', 'iip_search_app.views.viewinscr', name=u'inscription_url' ),
     url( r'^viewinscr_zotero/(?P<inscrid>.*)/$', 'iip_search_app.views.viewinscr_zotero', name='inscription_url_zotero'),
 

--- a/iip_search_app/views.py
+++ b/iip_search_app/views.py
@@ -305,6 +305,7 @@ def api_wrapper( request ):
     old_params = dict(request.GET)
     params = dict([(x.replace('.', '_'), old_params[x] if len(old_params[x]) > 1 else old_params[x][0]) for x in old_params])
     params['wt'] = 'json'
+    if(params['q']): params['q'] += " AND display_status:approved"
     s = solr.SolrConnection( settings_app.SOLR_URL )
 
     r = s.raw_query(**params)

--- a/iip_search_app/views.py
+++ b/iip_search_app/views.py
@@ -302,7 +302,14 @@ def _z_prepare_viewinscr_plain_get_response( q, z_bibids, specific_sources, curr
 ## api ##
 
 def api_wrapper( request ):
-    return HttpResponse( str(dict(request.GET)), content_type="application/json" )
+    old_params = dict(request.GET)
+    params = dict([(x.replace('.', '_'), old_params[x] if len(old_params[x]) > 1 else old_params[x][0]) for x in old_params])
+    params['wt'] = 'json'
+    s = solr.SolrConnection( settings_app.SOLR_URL )
+
+    r = s.raw_query(**params)
+
+    return HttpResponse( str(r), content_type="application/json" )
 
 ## login ##
 

--- a/iip_search_app/views.py
+++ b/iip_search_app/views.py
@@ -299,6 +299,10 @@ def _z_prepare_viewinscr_plain_get_response( q, z_bibids, specific_sources, curr
     return_response = render( request, u'iip_search_templates/viewinscr_zotero.html', context )
     return return_response
 
+## api ##
+
+def api_wrapper( request ):
+    return HttpResponse( str(dict(request.GET)), content_type="application/json" )
 
 ## login ##
 


### PR DESCRIPTION
Added a /api url that gives access to the /select handler of the solr index, and only returns approved inscriptions. This will hopefully solve a cross-origin and a security issue we were having with Dan's mapping code.