### PR TITLE
allow cross-origin requests to the API

### DIFF
--- a/iip_search_app/views.py
+++ b/iip_search_app/views.py
@@ -320,12 +320,15 @@ def api_wrapper( request ):
     old_params = dict(request.GET)
     params = dict([(x.replace('.', '_'), old_params[x] if len(old_params[x]) > 1 else old_params[x][0]) for x in old_params])
     params['wt'] = 'json'
-    if(params['q']): params['q'] += " AND display_status:approved"
+    if('q' in params and params['q']): params['q'] += " AND display_status:approved"
     s = solr.SolrConnection( settings_app.SOLR_URL )
 
     r = s.raw_query(**params)
 
-    return HttpResponse( str(r), content_type="application/json" )
+    resp = HttpResponse( str(r), content_type="application/json" )
+    resp['Access-Control-Allow-Origin'] = "*"
+
+    return resp
 
 ## login ##
 


### PR DESCRIPTION
This works, but with a bit of strange behavior: our django is set up to redirect urls that don't have a trailing slash to the same url that includes the slash, but that redirect lacks a CORS header.

So basically any requests to `/iip/api/?q=...` work fine, but `/iip/api?q=...` get denied by lack of header.

If that's fine, we can merge it, if not, I'd appreciate some help figuring out how to change it.

fyi @birkin 